### PR TITLE
Python 3.7 + Local timezone

### DIFF
--- a/snapbtr
+++ b/snapbtr
@@ -24,13 +24,14 @@ import re, math, time, os, os.path, sys, shutil, stat
 from colorama import Fore, Back, Style
 from datetime import datetime, timedelta
 
-VERSION='0.1'
+VERSION = '0.1'
 
-DATE_FORMAT = '%Y%m%d-%H%M%S' # date format used for directories to clean
+DATE_FORMAT = '%Y%m%d-%H%M%S'  # date format used for directories to clean
 DEFAULT_KEEP_BACKUPS = 2
 
 # find TIME_SCALE: t < 2**32 => e**(t/c) < 2**32
-TIME_SCALE = math.ceil(float((2**32)/math.log(2**32)))
+TIME_SCALE = math.ceil(float((2 ** 32) / math.log(2 ** 32)))
+
 
 def timef(x):
     """make value inverse exponential in the time passed"""
@@ -40,16 +41,18 @@ def timef(x):
                 time.strptime(
                     os.path.split(x)[1],
                     DATE_FORMAT))
-            /TIME_SCALE)
+            / TIME_SCALE)
     except:
         v = None
     return v
+
 
 def sorted_value(dirs):
     if len(dirs) <= 0:
         return dirs
     else:
         return _sorted_value(dirs)
+
 
 def test_quads(items):
     """
@@ -64,6 +67,7 @@ def test_quads(items):
     """
     return list((i) for i in quads(items))
 
+
 def quads(items):
     rest = iter(items)
     before = None
@@ -74,7 +78,8 @@ def quads(items):
         before = a
         a = b
         b = next
-    yield(before, a, b, None)
+    yield (before, a, b, None)
+
 
 def test_sorted_value(dirs):
     """
@@ -89,8 +94,10 @@ def test_sorted_value(dirs):
     """
     return list((i) for i in _sorted_value(dirs))
 
+
 def _sorted_value(dirs):
     """Iterate dirs, sorted by their relative value when deleted"""
+
     def poles(items):
         """Yield (items[0], items[1]), (items[1], items[2]), ... (items[n-1], items[n])"""
         rest = iter(items)
@@ -98,6 +105,7 @@ def _sorted_value(dirs):
         for next in rest:
             yield (last, next)
             last = next
+
     def all_but_last(items):
         """Yield items[0], ..., items[n-1]"""
         rest = iter(items)
@@ -167,17 +175,20 @@ def _sorted_value(dirs):
         if mkill == newest_element:
             # Protect ourselves. Last backup should not ever be deleted
             raise Exception("attempt to kill the newest backup")
-        del candidates[mkill] # That's not a candidate any longer, it's gonna go
+        del candidates[mkill]  # That's not a candidate any longer, it's gonna go
         yield mkill
+
 
 def freespace(path):
     st = os.statvfs(path)
     return st[statvfs.F_BFREE] * st[statvfs.F_FRSIZE]
 
+
 class Operations:
     def __init__(self, path, trace=None):
         self.tracef = trace
         self.snap_dir = path
+
     def check_call(self, args):
         cmd_str = " ".join(args)
         self.trace(cmd_str)
@@ -190,16 +201,20 @@ class Operations:
         if p.returncode != 0:
             raise Exception("failed %s" % cmd_str)
         return p.returncode
+
     def unsnap(self, dir):
         import subprocess
         args = ["btrfs", "subvolume", "delete",
                 os.path.join(self.snap_dir, dir)]
         self.check_call(args)
+
     def freespace(self):
         return freespace(self.snap_dir)
+
     def listdir(self):
         return [d for d in os.listdir(self.snap_dir)
                 if timef(d)]
+
     def snap(self, subvol_path):
         import subprocess
 
@@ -212,12 +227,18 @@ class Operations:
         args = ["btrfs", "subvolume", "snapshot",
                 subvol_path, new_snap_path]
         self.check_call(args)
+
     def datestamp(self):
-        return time.strftime(DATE_FORMAT, time.gmtime(None))
+        if USE_UTC:
+            return time.strftime(DATE_FORMAT, time.gmtime(None))
+        else:
+            return time.strftime(DATE_FORMAT, time.localtime(None))
+
     def trace(self, *args, **kwargs):
         f = self.tracef
         if f:
             f(*args, **kwargs)
+
 
 class FakeOperations(Operations):
     def __init__(self,
@@ -248,17 +269,21 @@ class FakeOperations(Operations):
         v = self.dirs[dir]
         self.space += v
         del self.dirs[dir]
+
     def listdir(self):
         self.trace("listdir() = %s", self.dirs.keys())
         return self.dirs.iterkeys()
+
     def freespace(self):
         self.trace("freespace() = %s", self.space)
         return self.space
+
     def datestamp(self):
         if not self.time_now:
             return super(FakeOperations, self).datestamp()
         else:
             return self.time_now
+
 
 class DryrunOperations(Operations):
     def snap(self, subvol_path):
@@ -266,11 +291,13 @@ class DryrunOperations(Operations):
         if os.path.commonprefix((path, os.getcwd())) != '/':
             path = os.path.relpath(path)
         print(Fore.GREEN + "+ " + path + Fore.RESET)
+
     def unsnap(self, dir):
         path = os.path.join(self.snap_dir, dir)
         if os.path.commonprefix((path, os.getcwd())) != '/':
             path = os.path.relpath(path)
         print(Fore.RED + "- " + path + Fore.RESET)
+
 
 def test_cleandir(free, backups, keep=DEFAULT_KEEP_BACKUPS, preserve=0):
     """
@@ -315,6 +342,7 @@ Reached the minimum number of backups to keep (6)
 Traceback (most recent call last):
 SystemExit: Number of backups is less then requested to keep
     """
+
     class targets_container:
         def __init__(self, keep, free, backups, preserve):
             self.keep_backups = keep
@@ -346,6 +374,7 @@ SystemExit: Number of backups is less then requested to keep
     new_free = ops.space
     return (new_free, dirs_remained)
 
+
 def test_filter_out_ndays(dirs, ndays, now_ts):
     """
 >>> test_filter_out_ndays(('20101201-000000', '20101202-000000',\
@@ -372,9 +401,11 @@ def test_filter_out_ndays(dirs, ndays, now_ts):
     ops = Operations(path='.', trace=None)
     return filter_out_ndays(ops, dirs, ndays, now_ts)
 
+
 def filter_out_ndays(ops, dirs, ndays, now_ts=None):
     """
     """
+
     def is_before(dir_name):
         return datetime.strptime(dir_name, DATE_FORMAT) < ndays_before
 
@@ -386,6 +417,7 @@ def filter_out_ndays(ops, dirs, ndays, now_ts=None):
     # print ndays_before
     return filter(is_before, dirs)
 
+
 def cleandir(operations, targets):
     """Perform actual cleanup using 'operations' until 'targets' are met"""
     trace = operations.trace
@@ -394,6 +426,7 @@ def cleandir(operations, targets):
     target_backups = targets.target_backups
     preserve_days = targets.preserve_days
     last_dirs = []
+
     def first(it):
         for x in it:
             return x
@@ -420,7 +453,7 @@ def cleandir(operations, targets):
 
         if target_fsp is not None:
             fsp = operations.freespace()
-            #print "+++ ", fsp, target_fsp, fsp >= target_fsp
+            # print "+++ ", fsp, target_fsp, fsp >= target_fsp
             if fsp >= target_fsp:
                 trace("Satisfied freespace target: %s with %s",
                       fsp, target_fsp)
@@ -463,6 +496,7 @@ def cleandir(operations, targets):
         dirs.remove(next_del)
         operations.unsnap(next_del)
 
+
 def default_trace(fmt, *args, **kwargs):
     if args is not None:
         print(fmt % args)
@@ -470,6 +504,7 @@ def default_trace(fmt, *args, **kwargs):
         print(fmt % kwargs)
     else:
         print(fmt)
+
 
 def main(argv):
     def args():
@@ -483,18 +518,18 @@ def main(argv):
                 'G': 3
             }
             form = "([0-9]+)(%s)?" % \
-                "|".join(x for x in mods.iterkeys() if x is not None)
+                   "|".join(x for x in mods.iterkeys() if x is not None)
             m = re.match(form, target_str, re.IGNORECASE)
             if m:
                 val, mod = m.groups()
-                return int(val) * 1024**mods[mod.upper()]
+                return int(val) * 1024 ** mods[mod.upper()]
             else:
                 raise "Invalid value: %s, expected: %s" % (target_str, form)
 
         parser = argparse.ArgumentParser(
             description='Create and kill btrfs snapshots',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter
-            )
+        )
 
         parser.add_argument('subvolume', nargs='?', default=None,
                             help='Path to backuping subvolume')
@@ -504,6 +539,10 @@ def main(argv):
         parser.add_argument('-c', '--do-clean', action='store_true',
                             default=False)
         parser.add_argument('-s', '--do-snap', action='store_true',
+                            default=False)
+
+        parser.add_argument('-l', '--local-time', action='store_true',
+                            help="Use local time instead of UTC",
                             default=False)
 
         parser.add_argument('-b', '--target-backups',
@@ -569,8 +608,9 @@ def main(argv):
 
         return pa, parser
 
-
     pa, parser = args()
+    global USE_UTC
+    USE_UTC = not pa.local_time
 
     if pa.verbose:
         trace = default_trace
@@ -599,9 +639,11 @@ def main(argv):
     if pa.do_clean:
         cleandir(operations=operations, targets=pa)
 
+
 if "__main__" == __name__:
     if "--doctest" in sys.argv:
         import doctest
+
         sys.exit(doctest.testmod())
     else:
         sys.exit(main(sys.argv))

--- a/snapbtr
+++ b/snapbtr
@@ -24,14 +24,13 @@ import re, math, time, os, os.path, sys, shutil, stat
 from colorama import Fore, Back, Style
 from datetime import datetime, timedelta
 
-VERSION = '0.1'
+VERSION='0.1'
 
-DATE_FORMAT = '%Y%m%d-%H%M%S'  # date format used for directories to clean
+DATE_FORMAT = '%Y%m%d-%H%M%S' # date format used for directories to clean
 DEFAULT_KEEP_BACKUPS = 2
 
 # find TIME_SCALE: t < 2**32 => e**(t/c) < 2**32
-TIME_SCALE = math.ceil(float((2 ** 32) / math.log(2 ** 32)))
-
+TIME_SCALE = math.ceil(float((2**32)/math.log(2**32)))
 
 def timef(x):
     """make value inverse exponential in the time passed"""
@@ -41,18 +40,16 @@ def timef(x):
                 time.strptime(
                     os.path.split(x)[1],
                     DATE_FORMAT))
-            / TIME_SCALE)
+            /TIME_SCALE)
     except:
         v = None
     return v
-
 
 def sorted_value(dirs):
     if len(dirs) <= 0:
         return dirs
     else:
         return _sorted_value(dirs)
-
 
 def test_quads(items):
     """
@@ -67,7 +64,6 @@ def test_quads(items):
     """
     return list((i) for i in quads(items))
 
-
 def quads(items):
     rest = iter(items)
     before = None
@@ -78,8 +74,7 @@ def quads(items):
         before = a
         a = b
         b = next
-    yield (before, a, b, None)
-
+    yield(before, a, b, None)
 
 def test_sorted_value(dirs):
     """
@@ -94,10 +89,8 @@ def test_sorted_value(dirs):
     """
     return list((i) for i in _sorted_value(dirs))
 
-
 def _sorted_value(dirs):
     """Iterate dirs, sorted by their relative value when deleted"""
-
     def poles(items):
         """Yield (items[0], items[1]), (items[1], items[2]), ... (items[n-1], items[n])"""
         rest = iter(items)
@@ -105,7 +98,6 @@ def _sorted_value(dirs):
         for next in rest:
             yield (last, next)
             last = next
-
     def all_but_last(items):
         """Yield items[0], ..., items[n-1]"""
         rest = iter(items)
@@ -175,20 +167,17 @@ def _sorted_value(dirs):
         if mkill == newest_element:
             # Protect ourselves. Last backup should not ever be deleted
             raise Exception("attempt to kill the newest backup")
-        del candidates[mkill]  # That's not a candidate any longer, it's gonna go
+        del candidates[mkill] # That's not a candidate any longer, it's gonna go
         yield mkill
-
 
 def freespace(path):
     st = os.statvfs(path)
     return st[statvfs.F_BFREE] * st[statvfs.F_FRSIZE]
 
-
 class Operations:
     def __init__(self, path, trace=None):
         self.tracef = trace
         self.snap_dir = path
-
     def check_call(self, args):
         cmd_str = " ".join(args)
         self.trace(cmd_str)
@@ -201,20 +190,16 @@ class Operations:
         if p.returncode != 0:
             raise Exception("failed %s" % cmd_str)
         return p.returncode
-
     def unsnap(self, dir):
         import subprocess
         args = ["btrfs", "subvolume", "delete",
                 os.path.join(self.snap_dir, dir)]
         self.check_call(args)
-
     def freespace(self):
         return freespace(self.snap_dir)
-
     def listdir(self):
         return [d for d in os.listdir(self.snap_dir)
                 if timef(d)]
-
     def snap(self, subvol_path):
         import subprocess
 
@@ -227,7 +212,6 @@ class Operations:
         args = ["btrfs", "subvolume", "snapshot",
                 subvol_path, new_snap_path]
         self.check_call(args)
-
     def datestamp(self):
         if USE_UTC:
             return time.strftime(DATE_FORMAT, time.gmtime(None))
@@ -238,7 +222,6 @@ class Operations:
         f = self.tracef
         if f:
             f(*args, **kwargs)
-
 
 class FakeOperations(Operations):
     def __init__(self,
@@ -269,21 +252,17 @@ class FakeOperations(Operations):
         v = self.dirs[dir]
         self.space += v
         del self.dirs[dir]
-
     def listdir(self):
         self.trace("listdir() = %s", self.dirs.keys())
         return self.dirs.iterkeys()
-
     def freespace(self):
         self.trace("freespace() = %s", self.space)
         return self.space
-
     def datestamp(self):
         if not self.time_now:
             return super(FakeOperations, self).datestamp()
         else:
             return self.time_now
-
 
 class DryrunOperations(Operations):
     def snap(self, subvol_path):
@@ -291,13 +270,11 @@ class DryrunOperations(Operations):
         if os.path.commonprefix((path, os.getcwd())) != '/':
             path = os.path.relpath(path)
         print(Fore.GREEN + "+ " + path + Fore.RESET)
-
     def unsnap(self, dir):
         path = os.path.join(self.snap_dir, dir)
         if os.path.commonprefix((path, os.getcwd())) != '/':
             path = os.path.relpath(path)
         print(Fore.RED + "- " + path + Fore.RESET)
-
 
 def test_cleandir(free, backups, keep=DEFAULT_KEEP_BACKUPS, preserve=0):
     """
@@ -342,7 +319,6 @@ Reached the minimum number of backups to keep (6)
 Traceback (most recent call last):
 SystemExit: Number of backups is less then requested to keep
     """
-
     class targets_container:
         def __init__(self, keep, free, backups, preserve):
             self.keep_backups = keep
@@ -374,7 +350,6 @@ SystemExit: Number of backups is less then requested to keep
     new_free = ops.space
     return (new_free, dirs_remained)
 
-
 def test_filter_out_ndays(dirs, ndays, now_ts):
     """
 >>> test_filter_out_ndays(('20101201-000000', '20101202-000000',\
@@ -401,11 +376,9 @@ def test_filter_out_ndays(dirs, ndays, now_ts):
     ops = Operations(path='.', trace=None)
     return filter_out_ndays(ops, dirs, ndays, now_ts)
 
-
 def filter_out_ndays(ops, dirs, ndays, now_ts=None):
     """
     """
-
     def is_before(dir_name):
         return datetime.strptime(dir_name, DATE_FORMAT) < ndays_before
 
@@ -417,7 +390,6 @@ def filter_out_ndays(ops, dirs, ndays, now_ts=None):
     # print ndays_before
     return filter(is_before, dirs)
 
-
 def cleandir(operations, targets):
     """Perform actual cleanup using 'operations' until 'targets' are met"""
     trace = operations.trace
@@ -426,7 +398,6 @@ def cleandir(operations, targets):
     target_backups = targets.target_backups
     preserve_days = targets.preserve_days
     last_dirs = []
-
     def first(it):
         for x in it:
             return x
@@ -453,7 +424,7 @@ def cleandir(operations, targets):
 
         if target_fsp is not None:
             fsp = operations.freespace()
-            # print "+++ ", fsp, target_fsp, fsp >= target_fsp
+            #print "+++ ", fsp, target_fsp, fsp >= target_fsp
             if fsp >= target_fsp:
                 trace("Satisfied freespace target: %s with %s",
                       fsp, target_fsp)
@@ -496,7 +467,6 @@ def cleandir(operations, targets):
         dirs.remove(next_del)
         operations.unsnap(next_del)
 
-
 def default_trace(fmt, *args, **kwargs):
     if args is not None:
         print(fmt % args)
@@ -504,7 +474,6 @@ def default_trace(fmt, *args, **kwargs):
         print(fmt % kwargs)
     else:
         print(fmt)
-
 
 def main(argv):
     def args():
@@ -518,18 +487,18 @@ def main(argv):
                 'G': 3
             }
             form = "([0-9]+)(%s)?" % \
-                   "|".join(x for x in mods.iterkeys() if x is not None)
+                "|".join(x for x in mods.iterkeys() if x is not None)
             m = re.match(form, target_str, re.IGNORECASE)
             if m:
                 val, mod = m.groups()
-                return int(val) * 1024 ** mods[mod.upper()]
+                return int(val) * 1024**mods[mod.upper()]
             else:
                 raise "Invalid value: %s, expected: %s" % (target_str, form)
 
         parser = argparse.ArgumentParser(
             description='Create and kill btrfs snapshots',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter
-        )
+            )
 
         parser.add_argument('subvolume', nargs='?', default=None,
                             help='Path to backuping subvolume')
@@ -639,11 +608,9 @@ def main(argv):
     if pa.do_clean:
         cleandir(operations=operations, targets=pa)
 
-
 if "__main__" == __name__:
     if "--doctest" in sys.argv:
         import doctest
-
         sys.exit(doctest.testmod())
     else:
         sys.exit(main(sys.argv))

--- a/snapbtr
+++ b/snapbtr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3.7
 #
 # snapbtr is a small utility that keeps snapshots of btrfs filesystems.
 # Copyright (C) 2017 Yuri Volchkov <yuri.volchkov@gmail.com>
@@ -20,9 +20,11 @@
 # Snapbtr is originally written by Helge Jensen. It is re-published
 # under the GPLv3 with his consent and blessing.
 
-import re, math, time, os, os.path, sys, shutil, stat, statvfs
+import re, math, time, os, os.path, sys, shutil, stat
 from colorama import Fore, Back, Style
 from datetime import datetime, timedelta
+
+VERSION='0.1'
 
 DATE_FORMAT = '%Y%m%d-%H%M%S' # date format used for directories to clean
 DEFAULT_KEEP_BACKUPS = 2
@@ -65,8 +67,8 @@ def test_quads(items):
 def quads(items):
     rest = iter(items)
     before = None
-    a = rest.next()
-    b = rest.next()
+    a = rest.__next__()
+    b = rest.__next__()
     for next in rest:
         yield (before, a, b, next)
         before = a
@@ -92,14 +94,14 @@ def _sorted_value(dirs):
     def poles(items):
         """Yield (items[0], items[1]), (items[1], items[2]), ... (items[n-1], items[n])"""
         rest = iter(items)
-        last = rest.next()
+        last = rest.__next__()
         for next in rest:
             yield (last, next)
             last = next
     def all_but_last(items):
         """Yield items[0], ..., items[n-1]"""
         rest = iter(items)
-        last = rest.next()
+        last = rest.__next__()
         for x in rest:
             yield last
             last = x
@@ -113,7 +115,7 @@ def _sorted_value(dirs):
     # Keep going as long as there is anything to remove
     while len(candidates) > 2:
         # Get candidates ordered by timestamp (as v is monitonic in timestamp)
-        remain = sorted((v, k) for k, v in candidates.iteritems())
+        remain = sorted((v, k) for k, v in candidates.items())
         newest_element = remain[-1][1]
         # Find the "amount of information we loose by deleting the
         # latest of the pair"
@@ -340,7 +342,7 @@ SystemExit: Number of backups is less then requested to keep
     targets = targets_container(keep, free, backups, preserve)
 
     cleandir(ops, targets)
-    dirs_remained = sorted((i) for (i, j) in ops.dirs.iteritems())
+    dirs_remained = sorted((i) for (i, j) in ops.dirs.items())
     new_free = ops.space
     return (new_free, dirs_remained)
 
@@ -450,7 +452,7 @@ def cleandir(operations, targets):
             victims_list = sorted_value(dirs)
 
         try:
-            next_del = victims_list.next()
+            next_del = victims_list.__next__()
         except StopIteration:
             trace("Can not satisfy targets - no more victims left")
             break
@@ -520,6 +522,9 @@ def main(argv):
                             default=0, type=int,
                             help='''Backups which are taken within
                             DAYS_N last days are untouchable''')
+
+        parser.add_argument('-V', '--version', action='version',
+                            version=VERSION)
 
         # TODO:
         # The target-freespace makes little sense in its current


### PR DESCRIPTION
1.) Since Python 2.7 is close to EOL, I changed this to work with Python 3.7
2.) I added a flag "-l" that uses local timezone instead of UTC for subvolume names. Reason: I am using this for hourly backups, and am interested in knowing when recent snapshots were created, compared to current time.